### PR TITLE
always build protos in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest as builder
+FROM ghcr.io/rust-lang/rust:nightly as builder
 WORKDIR /app
 RUN rustup default nightly
 # from https://stackoverflow.com/questions/58473606/cache-rust-dependencies-with-docker-build
@@ -8,6 +8,7 @@ COPY ./auxin/Cargo.toml /app/auxin/
 COPY ./auxin_cli/Cargo.toml /app/auxin_cli/
 RUN mkdir -p /app/auxin_cli/src /app/auxin/src
 COPY auxin_protos /app/auxin_protos
+COPY ./auxin_protos/build.rs.always /app/auxin_protos/build.rs
 WORKDIR /app/auxin_cli
 # build dummy auxin_cli using latest Cargo.toml/Cargo.lock
 RUN echo 'fn main() { println!("Dummy!"); }' > ./src/lib.rs
@@ -19,6 +20,7 @@ RUN rm -r /app/auxin/src /app/auxin_cli/src
 COPY ./auxin/src /app/auxin/src
 COPY ./auxin/data /app/auxin/data
 COPY ./auxin_cli/src /app/auxin_cli/src
+
 RUN find /app/auxin_cli
 RUN touch -a -m /app/auxin_cli/src/main.rs
 

--- a/auxin_protos/build.rs.always
+++ b/auxin_protos/build.rs.always
@@ -1,0 +1,20 @@
+use protobuf_codegen_pure::Customize;
+
+extern crate protobuf_codegen_pure;
+
+fn main() {
+	protobuf_codegen_pure::Codegen::new()
+		.out_dir("src/protos")
+		.inputs(&["protos/websocket.proto"])
+		.inputs(&["protos/signalservice.proto"])
+		.inputs(&["protos/sealed_sender.proto"])
+		.inputs(&["protos/storage.proto"])
+		.customize(Customize {
+			gen_mod_rs: Some(true),
+			serde_derive: Some(true),
+			..Default::default()
+		})
+		.include("protos")
+		.run()
+		.expect("Codegen failed.");
+}


### PR DESCRIPTION
We had two layers of hidden caching. This turns one of them off for docker. 